### PR TITLE
feat: 관리자 단어 추가 시 Gemini API로 예문 자동 생성

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,6 @@ SMTP_USE_SSL=False
 FLASK_ENV=development
 FLASK_PORT=5000
 DEBUG=True
+
+# Gemini API (단어 예문 자동 생성에 사용)
+GEMINI_API_KEY=your_gemini_api_key_here

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,3 +5,4 @@ python-dotenv==1.0.0
 Werkzeug==2.3.7
 APScheduler==3.10.4
 Flask-Mail==0.9.1
+google-generativeai==0.8.4

--- a/backend/src/config.py
+++ b/backend/src/config.py
@@ -35,4 +35,7 @@ class Config:
     # Scheduler
     SCHEDULER_ENABLED = os.getenv('SCHEDULER_ENABLED', 'True') == 'True'
     INACTIVITY_HOURS = int(os.getenv('INACTIVITY_HOURS', 2000))  # 2000시간
+
+    # Gemini API
+    GEMINI_API_KEY = os.getenv('GEMINI_API_KEY', '')
     

--- a/backend/src/modules/wordbook/routes.py
+++ b/backend/src/modules/wordbook/routes.py
@@ -1,10 +1,22 @@
 from flask import request, jsonify
 from . import wordbook_bp
 from .service import WordService
+from modules.auth.service import AuthService
+
+_auth_service = AuthService()
 
 
 def _get_request_data():
     return request.get_json(silent=True) or {}
+
+
+def _get_admin_token_info():
+    """Authorization 헤더에서 admin 토큰을 검증. 비admin이면 None 반환."""
+    auth_header = request.headers.get('Authorization')
+    token_info = _auth_service.is_valid_access_token(auth_header)
+    if not token_info or token_info.get('role') != 'admin':
+        return None
+    return token_info
 
 
 @wordbook_bp.route("", methods=["GET"])
@@ -28,6 +40,8 @@ def get_words():
 
 @wordbook_bp.route("", methods=["POST"])
 def create_word():
+    if not _get_admin_token_info():
+        return jsonify({"message": "관리자 권한이 필요합니다."}), 403
     data = _get_request_data()
     result = WordService.create_word(data=data)
     status_code = 201 if result and result.get("id") else 400
@@ -36,6 +50,8 @@ def create_word():
 
 @wordbook_bp.route("/<int:word_id>", methods=["PUT"])
 def update_word(word_id):
+    if not _get_admin_token_info():
+        return jsonify({"message": "관리자 권한이 필요합니다."}), 403
     data = _get_request_data()
     result = WordService.update_word(word_id=word_id, data=data)
     status_code = 200 if result and result.get("id") else 400
@@ -44,6 +60,8 @@ def update_word(word_id):
 
 @wordbook_bp.route("/<int:word_id>", methods=["DELETE"])
 def delete_word(word_id):
+    if not _get_admin_token_info():
+        return jsonify({"message": "관리자 권한이 필요합니다."}), 403
     result = WordService.delete_word(word_id=word_id)
     status_code = 200 if result.get("status") == "success" else 400
     return jsonify(result), status_code

--- a/backend/src/modules/wordbook/service.py
+++ b/backend/src/modules/wordbook/service.py
@@ -13,7 +13,7 @@ class WordService:
             return None
         try:
             genai.configure(api_key=api_key)
-            model = genai.GenerativeModel('gemini-2.0-flash')
+            model = genai.GenerativeModel('gemini-2.5-flash')
             prompt = (
                 f'Write one natural English example sentence using the word "{term}" '
                 f'(Korean meaning: {definition}). '

--- a/backend/src/modules/wordbook/service.py
+++ b/backend/src/modules/wordbook/service.py
@@ -1,8 +1,30 @@
 """Wordbook Service"""
+import google.generativeai as genai
+from config import Config
 from .repository import WordRepository, UserWordStatusRepository, UserRepository
 
 
 class WordService:
+    @staticmethod
+    def _generate_example_with_gemini(term, definition):
+        """Gemini API를 이용해 영어 예문을 자동 생성. 실패 시 None 반환."""
+        api_key = Config.GEMINI_API_KEY
+        if not api_key:
+            return None
+        try:
+            genai.configure(api_key=api_key)
+            model = genai.GenerativeModel('gemini-2.0-flash')
+            prompt = (
+                f'Write one natural English example sentence using the word "{term}" '
+                f'(Korean meaning: {definition}). '
+                f'Output only the sentence, nothing else.'
+            )
+            response = model.generate_content(prompt)
+            return response.text.strip()
+        except Exception as e:
+            print(f"Gemini API 예문 생성 실패: {e}")
+            return None
+
     @staticmethod
     def _normalize_word_payload(data):
         term = data.get("term") or data.get("english") or data.get("word_english")
@@ -40,6 +62,9 @@ class WordService:
         existing = WordRepository.find_by_term(term=term)
         if existing:
             return {"message": "이미 동일한 단어가 존재합니다."}
+
+        if not example:
+            example = WordService._generate_example_with_gemini(term, definition)
 
         return WordRepository.create(term=term, definition=definition, example=example)
 


### PR DESCRIPTION
- wordbook/service.py: _generate_example_with_gemini() 추가, 예문 미입력 시 Gemini 호출
- wordbook/routes.py: POST/PUT/DELETE에 admin 권한 체크 추가
- config.py: GEMINI_API_KEY 설정 항목 추가
- requirements.txt: google-generativeai==0.8.4 추가
- .env.example: GEMINI_API_KEY 항목 추가