### PR TITLE
feat: 연속 출석 로직을 퀴즈 완료 기준 KST로 수정

### DIFF
--- a/backend/src/modules/dashboard/repository.py
+++ b/backend/src/modules/dashboard/repository.py
@@ -11,8 +11,24 @@ class DashboardRepository:
         return results[0] if results else None
 
     def check_today_quiz_completed(self, user_no: int) -> bool:
-        # Check in game_records whether a record exists for the user with played_at date = today
-        query = "SELECT COUNT(*) AS cnt FROM LIVO.game_records WHERE user_id = %s AND DATE(played_at) = DATE(CONVERT_TZ(UTC_TIMESTAMP(), '+00:00', '+09:00'))"
+        """오늘(KST) 퀴즈 완료 여부"""
+        query = """
+        SELECT COUNT(*) AS cnt FROM LIVO.game_records
+        WHERE user_id = %s
+          AND DATE(played_at) = DATE(CONVERT_TZ(UTC_TIMESTAMP(), '+00:00', '+09:00'))
+        """
+        results = db.execute_query(query, (user_no,))
+        if not results:
+            return False
+        return results[0].get('cnt', 0) > 0
+
+    def check_yesterday_quiz_completed(self, user_no: int) -> bool:
+        """어제(KST) 퀴즈 완료 여부"""
+        query = """
+        SELECT COUNT(*) AS cnt FROM LIVO.game_records
+        WHERE user_id = %s
+          AND DATE(played_at) = DATE(CONVERT_TZ(UTC_TIMESTAMP(), '+00:00', '+09:00')) - INTERVAL 1 DAY
+        """
         results = db.execute_query(query, (user_no,))
         if not results:
             return False

--- a/backend/src/modules/dashboard/service.py
+++ b/backend/src/modules/dashboard/service.py
@@ -15,8 +15,15 @@ class DashboardService:
             attendance_streak = user.get('attendance_streak', 0)
             today_completed = self.repo.check_today_quiz_completed(user_no)
 
-            if attendance_streak < 1:
-                attendance_streak = 1
+            if today_completed:
+                # 오늘 퀴즈 완료 → 정상 streak 표시
+                if attendance_streak < 1:
+                    attendance_streak = 1
+            else:
+                # 오늘 퀴즈 미완료 → 어제도 안 풀었으면 streak 끊김(0)
+                yesterday_completed = self.repo.check_yesterday_quiz_completed(user_no)
+                if not yesterday_completed:
+                    attendance_streak = 0
 
             return {
                 "status": "success",

--- a/backend/src/modules/quiz/repository.py
+++ b/backend/src/modules/quiz/repository.py
@@ -31,37 +31,45 @@ class QuizRepository:
         return db.execute_update(query, (user_no, total, correct))
 
     def has_quiz_completed_today(self, user_no):
-        """오늘 이미 퀴즈를 제출했는지 확인"""
+        """오늘(KST) 이미 퀴즈를 제출했는지 확인"""
         query = """
         SELECT COUNT(*) AS cnt
         FROM LIVO.game_records
         WHERE user_id = %s
-                    AND DATE(played_at) = DATE(CONVERT_TZ(UTC_TIMESTAMP(), '+00:00', '+09:00'))
+          AND DATE(played_at) = DATE(CONVERT_TZ(UTC_TIMESTAMP(), '+00:00', '+09:00'))
         """
         rows = db.execute_query(query, (user_no,))
         return bool(rows and rows[0].get('cnt', 0) > 0)
 
-    def increment_attendance_streak(self, user_no):
-        """오늘 첫 퀴즈 완료 시 연속 출석을 1 증가"""
+    def had_quiz_yesterday(self, user_no):
+        """어제(KST) 퀴즈를 완료했는지 확인"""
         query = """
-        UPDATE LIVO.users
-        SET attendance_streak = COALESCE(attendance_streak, 0) + 1,
-            attendance_today = TRUE
-        WHERE user_no = %s
+        SELECT COUNT(*) AS cnt
+        FROM LIVO.game_records
+        WHERE user_id = %s
+          AND DATE(played_at) = DATE(CONVERT_TZ(UTC_TIMESTAMP(), '+00:00', '+09:00')) - INTERVAL 1 DAY
         """
-        return db.execute_update(query, (user_no,))
+        rows = db.execute_query(query, (user_no,))
+        return bool(rows and rows[0].get('cnt', 0) > 0)
 
-    def ensure_minimum_attendance_streak(self, user_no):
-        """오늘 퀴즈가 완료된 상태라면 최소 출석값을 1로 맞춤"""
-        query = """
-        UPDATE LIVO.users
-        SET attendance_streak = CASE
-                WHEN COALESCE(attendance_streak, 0) < 1 THEN 1
-                ELSE attendance_streak
-            END,
-            attendance_today = TRUE
-        WHERE user_no = %s
+    def update_attendance_streak(self, user_no):
+        """오늘 첫 퀴즈 완료 시 연속 출석 업데이트 (KST 기준).
+        어제 퀴즈 기록이 있으면 streak +1, 없으면 streak = 1 (리셋).
         """
+        if self.had_quiz_yesterday(user_no):
+            query = """
+            UPDATE LIVO.users
+            SET attendance_streak = COALESCE(attendance_streak, 0) + 1,
+                attendance_today = TRUE
+            WHERE user_no = %s
+            """
+        else:
+            query = """
+            UPDATE LIVO.users
+            SET attendance_streak = 1,
+                attendance_today = TRUE
+            WHERE user_no = %s
+            """
         return db.execute_update(query, (user_no,))
 
     def get_words_by_date_range(self, user_no, date_filter='all', limit=10):

--- a/backend/src/modules/quiz/service.py
+++ b/backend/src/modules/quiz/service.py
@@ -28,12 +28,18 @@ class QuizService:
         }
 
     def submit_result(self, user_no, total, correct):
-        """퀴즈 결과 저장 로직"""
+        """퀴즈 결과 저장 및 출석 처리 (KST 기준 오늘 첫 퀴즈 시에만)"""
         if total is None or correct is None:
             return {"status": "error", "message": "퀴즈 결과가 올바르지 않습니다."}
 
+        # 저장 전 오늘(KST) 첫 퀴즈 여부 확인
+        is_first_today = not self.repository.has_quiz_completed_today(user_no)
+
         success = self.repository.save_quiz_result(user_no, total, correct)
         if success:
+            # 오늘 첫 퀴즈 완료 시에만 출석 streak 업데이트
+            if is_first_today:
+                self.repository.update_attendance_streak(user_no)
             return {"status": "success", "message": "결과가 성공적으로 저장되었습니다."}
         return {"status": "error", "message": "저장 중 오류가 발생했습니다."}
 


### PR DESCRIPTION
- 퀴즈 제출 시에만 출석 인정 (단순 접속 제외)
- 모든 날짜 기준을 KST(UTC+9)로 통일
- 오늘 첫 퀴즈 완료 시 streak 자동 업데이트
  - 어제 퀴즈 기록 있으면 streak +1, 없으면 1로 리셋
- 대시보드: 오늘+어제 모두 미완료 시 streak 0으로 표시

quiz/repository.py:
  - had_quiz_yesterday() 추가 (KST 기준 어제 퀴즈 여부)
  - update_attendance_streak() 추가 (streak 증가/리셋 분기)
  - 미사용 increment_attendance_streak(), ensure_minimum_attendance_streak() 제거

quiz/service.py:
  - submit_result()에 오늘 첫 퀴즈 시 update_attendance_streak() 호출 추가

dashboard/repository.py:
  - check_yesterday_quiz_completed() 추가 (KST 기준)

dashboard/service.py:
  - 오늘 퀴즈 미완료 + 어제 퀴즈 미완료 → streak 0 표시